### PR TITLE
TextField validations and local existing names database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,83 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+.DS_Store
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/

--- a/WizardSchoolSignUpUIKit/WizardSchoolSignUpUIKit/Networking.swift
+++ b/WizardSchoolSignUpUIKit/WizardSchoolSignUpUIKit/Networking.swift
@@ -10,13 +10,25 @@ import Foundation
 typealias ValidateCompletion = (Result<Bool,Error>) -> Void
 
 class Networking {
-    
     /// Validates that the user name is available to use
     func validate(userName: String, completionHandler: @escaping ValidateCompletion) {
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.3) {
-            let isAvailable = Bool.random()
-            
+            let isAvailable = !Database.names.contains(userName)
             completionHandler(.success(isAvailable))
         }
     }
+}
+
+fileprivate struct Database {
+    static let names = [
+        "anna",
+        "valencia",
+        "john",
+        "janne",
+        "zelo",
+        "titus",
+        "kimmy",
+        "liliam",
+        "mike michael"
+    ]
 }

--- a/WizardSchoolSignUpUIKit/WizardSchoolSignUpUIKit/ViewController.swift
+++ b/WizardSchoolSignUpUIKit/WizardSchoolSignUpUIKit/ViewController.swift
@@ -40,23 +40,37 @@ class ViewController: UIViewController {
     }
 
     private func textDidChange(_ notification: Notification) -> Void {
-        guard
-            notification.object as? NSObject == userNameTextField,
-            let userName = userNameTextField.text
-        else { return }
-        validate(userName: userName.lowercased())
+        guard let notificationObject = notification.object as? NSObject else { return }
+        if notificationObject == userNameTextField, let userName = userNameTextField.text {
+            validate(userName: userName.lowercased())
+        } else if notificationObject == passwordTextField, let password = passwordTextField.text {
+            validate(password: password)
+        } else if notificationObject == passwordConfirmationTextField, let passwordConfirmation = passwordConfirmationTextField.text {
+            validate(password: passwordConfirmation, with: passwordTextField.text)
+        }
+    }
+
+    private func validate(password: String) {
+        let isValidPassword = password.count > 8
+        passwordIcon.tintColor = isValidPassword ? .systemGreen : .systemRed
+    }
+
+    private func validate(password: String, with userPassword: String?) {
+        let isValidPassword = password == userPassword
+        passwordConfirmationIcon.tintColor = isValidPassword ? .systemGreen : .systemRed
     }
 
     private func validate(userName: String) {
-         network.validate(userName: userName) { result in
-             switch result {
-             case .success(let isAvailable):
-                 DispatchQueue.main.async { [weak self] in
-                     self?.userNameIcon?.tintColor = isAvailable ? .systemGreen : .systemRed
-                 }
-             case .failure:
-                 break
-             }
-         }
-     }
+        network.validate(userName: userName) { result in
+            switch result {
+            case .success(let isAvailable):
+                DispatchQueue.main.async { [weak self] in
+                    self?.userName = userName
+                    self?.userNameIcon.tintColor = isAvailable ? .systemGreen : .systemRed
+                }
+            case .failure:
+                break
+            }
+        }
+    }
 }

--- a/WizardSchoolSignUpUIKit/WizardSchoolSignUpUIKit/ViewController.swift
+++ b/WizardSchoolSignUpUIKit/WizardSchoolSignUpUIKit/ViewController.swift
@@ -23,27 +23,30 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
-        userNameTextField.delegate = self
-        passwordTextField.delegate = self
-        passwordConfirmationTextField.delegate = self
-
+        NotificationCenter.default.addObserver(
+            forName: UITextField.textDidChangeNotification,
+            object: nil,
+            queue: .main,
+            using: textDidChange
+        )
     }
-    
-    
-}
 
-// MARK: - Text Field Delegate
-extension ViewController: UITextFieldDelegate {
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        
-        if textField == userNameTextField, let userName = userNameTextField.text {
-            validate(userName: userName)
-
-        }
-        return true
+    deinit {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UITextField.textDidChangeNotification,
+            object: nil
+        )
     }
-    
+
+    private func textDidChange(_ notification: Notification) -> Void {
+        guard
+            notification.object as? NSObject == userNameTextField,
+            let userName = userNameTextField.text
+        else { return }
+        validate(userName: userName.lowercased())
+    }
+
     private func validate(userName: String) {
          network.validate(userName: userName) { result in
              switch result {


### PR DESCRIPTION
### Summary
Adds local names "database" to mock our existing usernames, also, adds validation for all three username, password and password confirmation TextFields.

Also included a `.gitignore`  

### How to test
1. Open app.
2. Type user name `Anna`.
3. See how it is not valid.
4. Type a unique user name like `okrrr`.
5. See how it is valid.
6. Type a password with less than 8 characters and then another with more than 8 characters.
7. Type a password confirmation different than the original password.
8. Type a password confirmation equal to the original password.

### Demo

https://user-images.githubusercontent.com/18747072/105640114-31bd1c00-5e4a-11eb-8829-3d5ff115f2a5.mp4

