### PR TITLE
Initial SwiftUI implementation

### DIFF
--- a/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI.xcodeproj/project.pbxproj
+++ b/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI.xcodeproj/project.pbxproj
@@ -1,0 +1,331 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		DD6AAEF42610CDCE003B77D3 /* WizardSchoolSignUpSwiftUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6AAEF32610CDCE003B77D3 /* WizardSchoolSignUpSwiftUIApp.swift */; };
+		DD6AAEF62610CDCE003B77D3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6AAEF52610CDCE003B77D3 /* ContentView.swift */; };
+		DD6AAEF82610CDD0003B77D3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DD6AAEF72610CDD0003B77D3 /* Assets.xcassets */; };
+		DD6AAEFB2610CDD0003B77D3 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DD6AAEFA2610CDD0003B77D3 /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		DD6AAEF02610CDCE003B77D3 /* WizardSchoolSignUpSwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WizardSchoolSignUpSwiftUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD6AAEF32610CDCE003B77D3 /* WizardSchoolSignUpSwiftUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WizardSchoolSignUpSwiftUIApp.swift; sourceTree = "<group>"; };
+		DD6AAEF52610CDCE003B77D3 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		DD6AAEF72610CDD0003B77D3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		DD6AAEFA2610CDD0003B77D3 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		DD6AAEFC2610CDD0003B77D3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		DD6AAEED2610CDCE003B77D3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		DD6AAEE72610CDCE003B77D3 = {
+			isa = PBXGroup;
+			children = (
+				DD6AAEF22610CDCE003B77D3 /* WizardSchoolSignUpSwiftUI */,
+				DD6AAEF12610CDCE003B77D3 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		DD6AAEF12610CDCE003B77D3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				DD6AAEF02610CDCE003B77D3 /* WizardSchoolSignUpSwiftUI.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		DD6AAEF22610CDCE003B77D3 /* WizardSchoolSignUpSwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				DD6AAEF32610CDCE003B77D3 /* WizardSchoolSignUpSwiftUIApp.swift */,
+				DD6AAEF52610CDCE003B77D3 /* ContentView.swift */,
+				DD6AAEF72610CDD0003B77D3 /* Assets.xcassets */,
+				DD6AAEFC2610CDD0003B77D3 /* Info.plist */,
+				DD6AAEF92610CDD0003B77D3 /* Preview Content */,
+			);
+			path = WizardSchoolSignUpSwiftUI;
+			sourceTree = "<group>";
+		};
+		DD6AAEF92610CDD0003B77D3 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				DD6AAEFA2610CDD0003B77D3 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		DD6AAEEF2610CDCE003B77D3 /* WizardSchoolSignUpSwiftUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DD6AAEFF2610CDD0003B77D3 /* Build configuration list for PBXNativeTarget "WizardSchoolSignUpSwiftUI" */;
+			buildPhases = (
+				DD6AAEEC2610CDCE003B77D3 /* Sources */,
+				DD6AAEED2610CDCE003B77D3 /* Frameworks */,
+				DD6AAEEE2610CDCE003B77D3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = WizardSchoolSignUpSwiftUI;
+			productName = WizardSchoolSignUpSwiftUI;
+			productReference = DD6AAEF02610CDCE003B77D3 /* WizardSchoolSignUpSwiftUI.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		DD6AAEE82610CDCE003B77D3 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1220;
+				LastUpgradeCheck = 1220;
+				TargetAttributes = {
+					DD6AAEEF2610CDCE003B77D3 = {
+						CreatedOnToolsVersion = 12.2;
+					};
+				};
+			};
+			buildConfigurationList = DD6AAEEB2610CDCE003B77D3 /* Build configuration list for PBXProject "WizardSchoolSignUpSwiftUI" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = DD6AAEE72610CDCE003B77D3;
+			productRefGroup = DD6AAEF12610CDCE003B77D3 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				DD6AAEEF2610CDCE003B77D3 /* WizardSchoolSignUpSwiftUI */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		DD6AAEEE2610CDCE003B77D3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD6AAEFB2610CDD0003B77D3 /* Preview Assets.xcassets in Resources */,
+				DD6AAEF82610CDD0003B77D3 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		DD6AAEEC2610CDCE003B77D3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD6AAEF62610CDCE003B77D3 /* ContentView.swift in Sources */,
+				DD6AAEF42610CDCE003B77D3 /* WizardSchoolSignUpSwiftUIApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		DD6AAEFD2610CDD0003B77D3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		DD6AAEFE2610CDD0003B77D3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		DD6AAF002610CDD0003B77D3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"WizardSchoolSignUpSwiftUI/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = WizardSchoolSignUpSwiftUI/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.code-reviews.WizardSchoolSignUpSwiftUI.WizardSchoolSignUpSwiftUI";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		DD6AAF012610CDD0003B77D3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"WizardSchoolSignUpSwiftUI/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = WizardSchoolSignUpSwiftUI/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.code-reviews.WizardSchoolSignUpSwiftUI.WizardSchoolSignUpSwiftUI";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		DD6AAEEB2610CDCE003B77D3 /* Build configuration list for PBXProject "WizardSchoolSignUpSwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DD6AAEFD2610CDD0003B77D3 /* Debug */,
+				DD6AAEFE2610CDD0003B77D3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DD6AAEFF2610CDD0003B77D3 /* Build configuration list for PBXNativeTarget "WizardSchoolSignUpSwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DD6AAF002610CDD0003B77D3 /* Debug */,
+				DD6AAF012610CDD0003B77D3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = DD6AAEE82610CDCE003B77D3 /* Project object */;
+}

--- a/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/Assets.xcassets/Contents.json
+++ b/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/ContentView.swift
+++ b/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/ContentView.swift
@@ -8,9 +8,55 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var username: String = ""
+    @State private var password: String = ""
+    @State private var passwordConfirmation: String = ""
+
     var body: some View {
-        Text("Hello, world!")
+        NavigationView {
+            VStack(spacing: 24) {
+                textFields
+                createAccountButton
+                Spacer()
+            }
             .padding()
+            .navigationBarTitle("Wizard School Signup", displayMode: .inline)
+        }
+    }
+
+    private var textFields: some View {
+        VStack(spacing: 12) {
+            HStack {
+                Image(systemName: "person.circle")
+                TextField("Wizard name", text: $username)
+            }
+
+            HStack {
+                Image(systemName: "lock.circle")
+                TextField("Password", text: $password)
+            }
+
+            HStack {
+                Image(systemName: "lock.circle")
+                TextField("Password Confirmation", text: $passwordConfirmation)
+            }
+        }
+        .textFieldStyle(RoundedBorderTextFieldStyle())
+    }
+
+    private var createAccountButton: some View {
+        Button(action: {}, label: {
+            HStack {
+                Spacer()
+                Text("Create Account")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                Spacer()
+            }
+            .padding()
+            .background(Color.green)
+            .cornerRadius(8)
+        })
     }
 }
 

--- a/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/ContentView.swift
+++ b/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/ContentView.swift
@@ -1,0 +1,21 @@
+//
+//  ContentView.swift
+//  WizardSchoolSignUpSwiftUI
+//
+//  Created by Jhonny Bill on 3/28/21.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/Info.plist
+++ b/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUIApp.swift
+++ b/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUI/WizardSchoolSignUpSwiftUIApp.swift
@@ -1,0 +1,17 @@
+//
+//  WizardSchoolSignUpSwiftUIApp.swift
+//  WizardSchoolSignUpSwiftUI
+//
+//  Created by Jhonny Bill on 3/28/21.
+//
+
+import SwiftUI
+
+@main
+struct WizardSchoolSignUpSwiftUIApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
### Summary
Adds a new SwiftUI project named `WizardSchoolSignUpSwiftUI`, to recreate all we did in `WizardSchoolSignUpUIKit`. Also added the initial SignUp view implementation.

### How to test
1. Open `WizardSchoolSignUpSwiftUI`.
2. Run the project.
3. See the view looks like our UIKit version.
4. Type something in each one of the TextFields.
5. See the TextFields show your typed content, but do not perform validation.
6. Increase your font size.
7. See the views growth accordingly (default SwiftUI behavior).

### Demo

Default | Typed content | Huge | Dark
--- | --- | --- | ---
![WIZARD-SWIFT-UI-DEFAULT](https://user-images.githubusercontent.com/18747072/112764926-af331300-8fd8-11eb-814d-c235cd2ec6c6.png) | ![WIZARD-SWIFT-UI-USERNAME](https://user-images.githubusercontent.com/18747072/112764925-acd0b900-8fd8-11eb-949c-6302f63a715b.png) | ![WIZARD-SWIFT-UI-HUGE](https://user-images.githubusercontent.com/18747072/112764922-ab06f580-8fd8-11eb-8d5b-de23cfb4f01f.png) | ![WIZARD-SWIFT-UI-DARK](https://user-images.githubusercontent.com/18747072/112764918-a6dad800-8fd8-11eb-8e93-a3e984e841db.png)

